### PR TITLE
refactor the draft workflow

### DIFF
--- a/.github/workflows/ci-draft.yml
+++ b/.github/workflows/ci-draft.yml
@@ -86,6 +86,17 @@ jobs:
           echo "Building with ARTEFACT_VERSION=$ARTEFACT_VERSION using Java $JAVA_VERSION"
           gradle build -DAPI_SPEC_VERSION=$ARTEFACT_VERSION
 
+  Push-Draft-OpenAPI-Spec:
+    needs: [Test]
+    uses: ./.github/workflows/push-draft-openapi-spec.yml
+    secrets:
+      SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+    with:
+      upload_artifact_name: ${{ needs.Update-Spec-Version.outputs.upload_artifact_name }}
+      apihub_owner: hmcts-dts
+      api_name: ${{ github.event.repository.name }}
+      api_version: ${{ needs.Artefact-Version.outputs.artefact_version }}
+
   Publish:
     name: Publish Artefact
     if: github.event_name == 'push'

--- a/.github/workflows/push-draft-openapi-spec.yml
+++ b/.github/workflows/push-draft-openapi-spec.yml
@@ -1,80 +1,36 @@
 name: Push Draft OpenAPI Spec to APIHub
+description: |
+  This workflow pushes a draft version of the OpenAPI spec to APIHub.
+  It is triggered by the `workflow_call` event and requires an API key and other inputs.
+  The OpenAPI spec is expected to be downloaded as an artifact before this workflow runs.
 
 on:
-  push:
-    branches:
-      - main
-      - master
-
-env:
-  FILE_PATH_OPENAPI: "src/main/resources/openapi"
+  workflow_call:
+    secrets:
+      SWAGGERHUB_API_KEY:
+        required: true
+    inputs:
+      upload_artifact_name:
+        required: true
+        type: string
+      apihub_owner:
+        required: true
+        type: string
+      api_name:
+        required: true
+        type: string
+      api_version:
+        required: true
+        type: string
 
 jobs:
-  API-Version:
-    runs-on: ubuntu-latest
-    outputs:
-      artefact_version: ${{ steps.artefact.outputs.draft_version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate Artefact Version
-        id: artefact
-        uses: hmcts/artefact-version-action@v1
-        with:
-          release: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  Apply-Version-to-API-Spec:
-    needs: [API-Version]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Find OpenAPI file
-        id: find_spec
-        run: |
-          FILE=$(find "${FILE_PATH_OPENAPI}" -name "*.openapi.yml" | head -n 1)
-          if [ -z "$FILE" ]; then
-            echo "⚠️ *** No OpenAPI spec (*.openapi.yml) found. Skipping publishing draft. ***"
-            exit 1
-          fi
-          echo "openapi_file=$FILE" >> $GITHUB_OUTPUT
-
-      - name: Update info.version in OpenAPI spec using yq
-        env:
-          API_NAME: ${{ github.event.repository.name }}
-          API_VERSION: ${{ needs.API-Version.outputs.artefact_version }}
-        uses: mikefarah/yq@v4.45.4
-        with:
-          cmd: |
-            yq '
-              .info.version = strenv(API_VERSION) |
-              .servers[0].url = "https://virtserver.swaggerhub.com/HMCTS-DTS/" + strenv(API_NAME) + "/" + strenv(API_VERSION)
-            ' "${{ steps.find_spec.outputs.openapi_file }}" > openapi-versioned.yml
-
-      - name: Upload updated OpenAPI file
-        uses: actions/upload-artifact@v4
-        with:
-          name: updated-openapi-spec
-          path: openapi-versioned.yml
-
   Push-API-to-APIHub:
-    needs: [API-Version, Apply-Version-to-API-Spec]
     runs-on: ubuntu-latest
-    env:
-      SWAGGERHUB_API_KEY: ${{ secrets.APIHUB_API_KEY }}
-
     steps:
       - name: Download versioned OpenAPI spec
         uses: actions/download-artifact@v4
         with:
-          name: updated-openapi-spec
+          name: ${{ inputs.upload_artifact_name }}
           path: ./
 
       - name: Set up Node.js
@@ -85,10 +41,10 @@ jobs:
 
       - name: Set CLI_API_REF env var
         env:
-          SWAGGERHUB_API_KEY: ${{ secrets.APIHUB_API_KEY }}
+          SWAGGERHUB_API_KEY: ${{ inputs.is_release }}
           APIHUB_OWNER: ${{ vars.APIHUB_ORGANISATION }}
-          API_NAME: ${{ github.event.repository.name }}
-          API_VERSION: ${{ needs.API-Version.outputs.artefact_version }}
+          API_NAME: ${{ inputs.api_name }}
+          API_VERSION: ${{ inputs.api_version }}
         run: |
           echo "CLI_API_REF=${APIHUB_OWNER}/${API_NAME}/${API_VERSION}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The CI-Draft workflow now calls the push open api spec workflow to accommodate the upcoming introduction of Pactflow
